### PR TITLE
1.5.5

### DIFF
--- a/corpoch/admin.py
+++ b/corpoch/admin.py
@@ -54,7 +54,7 @@ class DiscordUserAdmin(admin.ModelAdmin):
 
 @admin.register(Chart)
 class ChartAdmin(admin.ModelAdmin):
-	list_display = ('_icon','name',  '_bracket', 'charter', 'artist', 'album', 'speed', '_modifiers', 'tiebreaker')
+	list_display = ('_icon','name', '_bracket', 'charter', 'artist', 'album', '_category', 'speed', '_modifiers', 'boss', 'tiebreaker')
 	list_filter = ['brackets__tournament', 'tiebreaker', 'boss']
 	actions = ['run_encore_import', 'import_song_ini']
 	readonly_fields = ['_icon', 'game_version']
@@ -68,13 +68,10 @@ class ChartAdmin(admin.ModelAdmin):
 		return retList
 
 	def _modifiers(self, obj):
-		return obj.modifiers
+		return obj.modifiers_short
 
-	def modifiers_long(self, obj):
-		out = []
-		for i in range(0, len(obj.modifiers)):
-			out.append(CH_MODIFIERS[i][1])
-		return out
+	def _category(self, obj):
+		return obj.category.capitalize()
 
 	@mark_safe
 	def _icon(self, obj):
@@ -98,6 +95,9 @@ class ChartAdmin(admin.ModelAdmin):
 
 	def get_queryset(self, request):
 		qs = super().get_queryset(request)
+		#Ensure DEV envs always return for SU's
+		if settings.DEBUG and request.user.is_superuser:
+			return qs
 
 		for obj in qs:
 			for bracket in obj.brackets.all():
@@ -302,14 +302,15 @@ class TournamentPlayerAdmin(admin.ModelAdmin):
 					corpoch.dbot.tasks.set_group_role(ply.user.id, guild.id, grole.id)
 				if brole is not None:
 					corpoch.dbot.tasks.set_group_role(ply.user.id, guild.id, brole.id)
-				if trole is not None:
-					corpoch.dbot.tasks.set_group_role(ply.user.id, guild.id, trole.id)
+			if trole is not None:
+				corpoch.dbot.tasks.set_group_role(ply.user.id, guild.id, trole.id)
 
 @admin.register(Qualifier)
 class QualifierAdmin(admin.ModelAdmin):
 	list_display = ('id', 'tournament', '_players', '_submissions')
 	list_filter = ['tournament']
 	actions = ['submit_final_scores']
+	filter_horizontal = ['charts']
 
 	def _players(self, obj):
 		return QualifierSubmission.objects.all().filter(qualifier__tournament=obj.tournament).values('player').distinct().count()

--- a/corpoch/admin.py
+++ b/corpoch/admin.py
@@ -68,6 +68,10 @@ class ChartAdmin(admin.ModelAdmin):
 		retList = []
 		for bracket in obj.brackets.iterator():
 			retList.append(bracket)
+
+		for quali in Qualifier.objects.all().filter(charts__in=[obj]):
+			retList.append(f"{quali} Qualifier")
+
 		return retList
 
 	def _category(self, obj):

--- a/corpoch/admin.py
+++ b/corpoch/admin.py
@@ -54,21 +54,21 @@ class DiscordUserAdmin(admin.ModelAdmin):
 
 @admin.register(Chart)
 class ChartAdmin(admin.ModelAdmin):
-	list_display = ('_icon','name', '_bracket', 'charter', 'artist', 'album', '_category', 'speed', '_modifiers', 'boss', 'tiebreaker')
+	list_display = ('_icon','_tournament_name', '_brackets', '_category', 'boss', 'tiebreaker')
 	list_filter = ['brackets__tournament', 'tiebreaker', 'boss']
 	actions = ['run_encore_import', 'import_song_ini']
 	readonly_fields = ['_icon', 'game_version']
 	search_fields = ('name', 'charter')
 	filter_horizontal = ['brackets']
 
-	def _bracket(self,obj):
+	def _tournament_name(self, obj):
+		return obj.tournament_name
+
+	def _brackets(self, obj):
 		retList = []
 		for bracket in obj.brackets.iterator():
 			retList.append(bracket)
 		return retList
-
-	def _modifiers(self, obj):
-		return obj.modifiers_short
 
 	def _category(self, obj):
 		return obj.category.capitalize()

--- a/corpoch/dbot/cogs/qualifiercmds.py
+++ b/corpoch/dbot/cogs/qualifiercmds.py
@@ -218,6 +218,9 @@ class DiscordQualifierView(discord.ui.View):
 		elif steg.output.playback_speed != playedChart.speed:
 			print(f"QUALIFIER: {self.qualifier}: {self.ctx.user.display_name} screenshot speed {steg.output.playback_speed}% does not match speed of qualifier: {playedChart.speed}%")
 			await interaction.followup.send(f"Uploaded screenshot speed ({steg.output.playback_speed}%) does not match speed of qualifier: {playedChart.speed}%", ephemeral=True, delete_after=10)
+		elif set(steg.output.players[0].modifiers) != set(playedChart.modifiers_steg):
+			await interaction.followup.send(f"Uploaded Screenshot has incorrect modifiers {steg.output.players[0].modifiers} does not modifiers for  qualifier: {playedChart.modifiers_steg}", ephemeral=True, delete_after=10)
+			print(f"QUALIFIER: Screenshot player {steg.output.players[0].profile_name} has incorrect modifiers {steg.output.players[0].modifiers} for qualifier: {playedChart.modifiers_steg}")
 		else:
 			print(f"QUALIFIER: {self.ctx.user.display_name} screenshot {steg.img_name} accepted")
 			self.screen = modal.screen

--- a/corpoch/dbot/view/path.py
+++ b/corpoch/dbot/view/path.py
@@ -168,12 +168,11 @@ class BracketSelect(discord.ui.Select):
 
 	async def init(self):
 		opts = []
-		try:
-			admin = bracket.tournament.guild.admins.get(pk=self.path.user.id)
-		except DiscordUser.DoesNotExist:
-			admin = None
-
 		async for bracket in self.path.tournament.brackets.select_related():
+			try:
+				admin = bracket.tournament.guild.admins.get(pk=self.path.user.id)
+			except DiscordUser.DoesNotExist:
+				admin = None
 			if bracket.revealed or admin:
 				self.retOpts[str(bracket)] = bracket
 				opts.append(discord.SelectOption(label=str(bracket), default=True if self.path.bracket == bracket else False))

--- a/corpoch/dbot/view/reftool.py
+++ b/corpoch/dbot/view/reftool.py
@@ -468,7 +468,7 @@ class DiscordMatchView(discord.ui.View):
 				print(f"MATCH SCREENSHOT: {interaction.user.global_name} screenshot {screen.filename} game version {steg.game_version} does not match tournament {self.tournament.config.version}")
 				continue
 
-			stop = False
+			#Check Player Cound
 			if len(steg.players) < self.match.ruleset.num_players:
 				print(f"MATCH SCREENSHOT: Screenshot {screen.filename} has missing players. Adding to review.")
 				msg	= await interaction.followup.send(f"Screenshot {screen.filename} has missing players but is otherwise correct. If this due to a disconnect/issues, please have the ref verify this or reach out to staff!")
@@ -478,18 +478,20 @@ class DiscordMatchView(discord.ui.View):
 				print(f"MATCH SCREENSHOT: Screenshot {screen.filename} has too many players.")
 				await interaction.followup.send(f"Screenshot {screen.filename} has too many players.", ephemeral=True, delete_after=10)
 				continue
-			else:				
-				for seed in self.match.seeding:
-					if not seed.player.check_ch_name(steg.players[0].profile_name) and not seed.player.check_ch_name(steg.players[1].profile_name):
-						print(f"MATCH SCREENSHOT: {interaction.user.global_name} screenshot {screen.filename} players do not match players for this match")
-						await interaction.followup.send(f"Screenshot {screen.filename} does not match players for this match", ephemeral=True, delete_after=10)
-						stop = True
-						break
-				if stop:
-					continue
+
+			#Check Player Names
+			stop = False
+			for seed in self.match.seeding:
+				if not seed.player.check_ch_name(steg.players[0].profile_name) and not seed.player.check_ch_name(steg.players[1].profile_name):
+					print(f"MATCH SCREENSHOT: {interaction.user.global_name} screenshot {screen.filename} players do not match players for this match")
+					await interaction.followup.send(f"Screenshot {screen.filename} does not match players for this match", ephemeral=True, delete_after=10)
+					stop = True
+					break
+			if stop:
+				continue
 			#Check modifiers
 			for player in steg.players:
-				if player.modifiers.sort() != playedChart.modifiers_steg:
+				if set(player.modifiers) != set(playedChart.modifiers_steg):
 					await interaction.followup.send(f"Screenshot {screen.filename} player {player.profile_name} has incorrect modifiers {player.modifiers} for chart {playedChart.modifiers_steg}", ephemeral=True, delete_after=10)
 					print(f"MATCH SCREEENSHOT: Screenshot {screen.filename} player {player.profile_name} has incorrect modifiers {player.modifiers} for chart {playedChart.modifiers_steg}")
 					stop = True

--- a/corpoch/dbot/view/reftool.py
+++ b/corpoch/dbot/view/reftool.py
@@ -468,6 +468,7 @@ class DiscordMatchView(discord.ui.View):
 				print(f"MATCH SCREENSHOT: {interaction.user.global_name} screenshot {screen.filename} game version {steg.game_version} does not match tournament {self.tournament.config.version}")
 				continue
 
+			stop = False
 			if len(steg.players) < self.match.ruleset.num_players:
 				print(f"MATCH SCREENSHOT: Screenshot {screen.filename} has missing players. Adding to review.")
 				msg	= await interaction.followup.send(f"Screenshot {screen.filename} has missing players but is otherwise correct. If this due to a disconnect/issues, please have the ref verify this or reach out to staff!")
@@ -477,8 +478,7 @@ class DiscordMatchView(discord.ui.View):
 				print(f"MATCH SCREENSHOT: Screenshot {screen.filename} has too many players.")
 				await interaction.followup.send(f"Screenshot {screen.filename} has too many players.", ephemeral=True, delete_after=10)
 				continue
-			else:
-				stop = False
+			else:				
 				for seed in self.match.seeding:
 					if not seed.player.check_ch_name(steg.players[0].profile_name) and not seed.player.check_ch_name(steg.players[1].profile_name):
 						print(f"MATCH SCREENSHOT: {interaction.user.global_name} screenshot {screen.filename} players do not match players for this match")
@@ -487,6 +487,15 @@ class DiscordMatchView(discord.ui.View):
 						break
 				if stop:
 					continue
+			#Check modifiers
+			for player in steg.players:
+				if player.modifiers.sort() != playedChart.modifiers_steg:
+					await interaction.followup.send(f"Screenshot {screen.filename} player {player.profile_name} has incorrect modifiers {player.modifiers} for chart {playedChart.modifiers_steg}", ephemeral=True, delete_after=10)
+					print(f"MATCH SCREEENSHOT: Screenshot {screen.filename} player {player.profile_name} has incorrect modifiers {player.modifiers} for chart {playedChart.modifiers_steg}")
+					stop = True
+					break
+			if stop:
+				continue
 			try:
 				rnd = await self.match.matchDb.rounds.aget(chart=playedChart)
 			except MatchRound.DoesNotExist:

--- a/corpoch/dbot/view/reftool.py
+++ b/corpoch/dbot/view/reftool.py
@@ -447,6 +447,7 @@ class DiscordMatchView(discord.ui.View):
 		self.is_uploading = True
 		for screen in modal.screens:
 			tool = CHStegTool()
+			review = None
 			try:
 				steg = await tool.getStegInfo(screen)
 				rnd = await self.match.rounds.select_related('chart').aget(chart__md5=steg.checksum)
@@ -468,27 +469,21 @@ class DiscordMatchView(discord.ui.View):
 				print(f"MATCH SCREENSHOT: {interaction.user.global_name} screenshot {screen.filename} game version {steg.game_version} does not match tournament {self.tournament.config.version}")
 				continue
 
-			#Check Player Cound
-			if len(steg.players) < self.match.ruleset.num_players:
-				print(f"MATCH SCREENSHOT: Screenshot {screen.filename} has missing players. Adding to review.")
-				msg	= await interaction.followup.send(f"Screenshot {screen.filename} has missing players but is otherwise correct. If this due to a disconnect/issues, please have the ref verify this or reach out to staff!")
-				self.match.screen_review.append(RoundReview(self.match.matchDb, msg, screen, steg))
-				continue
-			elif len(steg.players) > self.match.ruleset.num_players:
-				print(f"MATCH SCREENSHOT: Screenshot {screen.filename} has too many players.")
-				await interaction.followup.send(f"Screenshot {screen.filename} has too many players.", ephemeral=True, delete_after=10)
-				continue
-
 			#Check Player Names
 			stop = False
-			for seed in self.match.seeding:
-				if not seed.player.check_ch_name(steg.players[0].profile_name) and not seed.player.check_ch_name(steg.players[1].profile_name):
+			for player in steg.players:
+				matched = False
+				for seed in self.match.seeding:
+					if not seed.player.check_ch_name(player.profile_name):
+						matched = True
+						break
+
+				if not matched:
 					print(f"MATCH SCREENSHOT: {interaction.user.global_name} screenshot {screen.filename} players do not match players for this match")
 					await interaction.followup.send(f"Screenshot {screen.filename} does not match players for this match", ephemeral=True, delete_after=10)
 					stop = True
 					break
-			if stop:
-				continue
+
 			#Check modifiers
 			for player in steg.players:
 				if set(player.modifiers) != set(playedChart.modifiers_steg):
@@ -496,8 +491,23 @@ class DiscordMatchView(discord.ui.View):
 					print(f"MATCH SCREEENSHOT: Screenshot {screen.filename} player {player.profile_name} has incorrect modifiers {player.modifiers} for chart {playedChart.modifiers_steg}")
 					stop = True
 					break
+
+			#Check Player Cound
+			if len(steg.players) < self.match.ruleset.num_players and not stop:
+				print(f"MATCH SCREENSHOT: Screenshot {screen.filename} has missing players. Adding to review.")
+				msg	= await interaction.followup.send(f"Screenshot {screen.filename} has missing players but is otherwise correct. If this due to a disconnect/issues, please have the ref verify this or reach out to staff!")
+				review = RoundReview(self.match.matchDb, msg, screen, steg)
+				stop = True
+			elif len(steg.players) > self.match.ruleset.num_players and not stop:
+				print(f"MATCH SCREENSHOT: Screenshot {screen.filename} has too many players.")
+				await interaction.followup.send(f"Screenshot {screen.filename} has too many players.", ephemeral=True, delete_after=10)
+				stop = True
+
 			if stop:
+				if review:
+					self.match.screen_review.append(review)
 				continue
+
 			try:
 				rnd = await self.match.matchDb.rounds.aget(chart=playedChart)
 			except MatchRound.DoesNotExist:

--- a/corpoch/models.py
+++ b/corpoch/models.py
@@ -200,11 +200,33 @@ class Chart(models.Model):
 	@property
 	def modifiers_short(self):
 		outStr = ""
-		if self.modifiers[0][1] != "NoModifiers":
+		if self.modifiers[0] == "NM":
 			return outStr
 		else:
 			for mod in self.modifiers:
-				outStr += f" ,{mod[0]}"
+				outStr += f" {mod}"
+			return outStr
+
+	@property
+	def modifiers_long(self):
+		return " ".join(self.modifiers_list)
+
+	@property
+	def modifiers_list(self) -> list:
+		out = []
+		for i in range(0, len(self.modifiers)):
+			for mod in CH_MODIFIERS:
+				if mod[0] == self.modifiers[i]:
+					out.append(mod[1])
+		return out
+
+	@property
+	def modifiers_steg(self) -> list:
+		retList = []
+		for mod in self.modifiers_list:
+			retList.append(mod.replace(" ", ""))
+		return retList
+
 	@property
 	def tournament_name(self):
 		retStr = f"{self.name}"

--- a/corpoch/models.py
+++ b/corpoch/models.py
@@ -200,15 +200,14 @@ class Chart(models.Model):
 	@property
 	def modifiers_short(self):
 		outStr = ""
-		if self.modifiers[0] == "NM":
-			return outStr
-		else:
+		if self.modifiers[0] != "NM":
 			for i, mod in enumerate(self.modifiers):
 				if i == 0:
 					outStr += mod
 				else:
 					outStr += f" {mod}"
-			return outStr
+
+		return outStr
 
 	@property
 	def modifiers_long(self):

--- a/corpoch/models.py
+++ b/corpoch/models.py
@@ -203,8 +203,11 @@ class Chart(models.Model):
 		if self.modifiers[0] == "NM":
 			return outStr
 		else:
-			for mod in self.modifiers:
-				outStr += f" {mod}"
+			for i, mod in enumerate(self.modifiers):
+				if i == 0:
+					outStr += mod
+				else:
+					outStr += f" {mod}"
 			return outStr
 
 	@property
@@ -233,7 +236,7 @@ class Chart(models.Model):
 		if self.speed != 100:
 			retStr += f" ({self.speed}%)"
 		if self.modifiers != ['NM']:
-			retStr += self.modifiers_short
+			retStr += f" [{self.modifiers_short}]"
 		return retStr
 
 	def __str__(self):

--- a/corpoch/types.py
+++ b/corpoch/types.py
@@ -9,12 +9,12 @@ CH_MODIFIERS = (
 	("AO", "All Opens"),
 	("BM", "Brutal Mode"),
 	("DD", "Deadly Dynamics"),
+	("DK", "Double Kick"),
 	("DN", "Double Notes"),
 	("DS", "Dropless Sustains"),
-	("PM", "Precision Mode"),
-	("NS", "Note Shuffle"),
-	("DK", "Double Kick"),
 	("NK", "No Kick"),
+	("NS", "Note Shuffle"),
+	("PM", "Precision Mode"),
 )
 
 CH_VERSIONS = (


### PR DESCRIPTION
Reworks Chart modifiers.
 - Allows for steg output checking for submitted screenshot modifiers
   - Both Qualifier and Match now do these checks

Admin cleanup
 - Chart view now uses tournament name, includes category and boss song status
 - Qualifier charts now reports in place of brackets where applicable
 - Qualifier charts view now filter_horizontal
 - Relaxes ChartAdmin queryset to allow SU users to see all charts in DEV envs

Fixes path generation with 1.5.4's bracket check allowing guild admins/staff to generate paths for unrevealed setlists